### PR TITLE
[#25] Feat: 보호대상자 건강정보 등록

### DIFF
--- a/src/main/java/hansung/ElderCare/Server/controller/ProtectedController.java
+++ b/src/main/java/hansung/ElderCare/Server/controller/ProtectedController.java
@@ -88,4 +88,11 @@ public class ProtectedController implements ProtectedSpecification {
         return ApiResponse.onSuccess();
     }
 
+    @Override
+    @GetMapping("/health")
+    public ApiResponse<?> getHealthInfo() {
+        ProtectedResponseDTO.protectedHealthInfo protectedHealthInfo = protectedQueryService.getProtectedHealthInfo(2L);
+        return ApiResponse.onSuccess(protectedHealthInfo);
+    }
+
 }

--- a/src/main/java/hansung/ElderCare/Server/controller/specification/ProtectedSpecification.java
+++ b/src/main/java/hansung/ElderCare/Server/controller/specification/ProtectedSpecification.java
@@ -39,4 +39,8 @@ public interface ProtectedSpecification {
     @PostMapping
     @Operation(summary = "보호대상자 건강정보 등록하기", description = "보호대상자 건강정보 데이터를 받아 저장")
     public ApiResponse<?> registerHealthInfo(ProtectedRequestDTO.ProtectedHealthInfo request, BindingResult bindingResult);
+
+    @GetMapping
+    @Operation(summary = "보호대상자 건강정보 조회", description = "보호대상자 건강정보 조회")
+    public ApiResponse<?> getHealthInfo();
 }

--- a/src/main/java/hansung/ElderCare/Server/dto/ProtectedDTO/ProtectedResponseDTO.java
+++ b/src/main/java/hansung/ElderCare/Server/dto/ProtectedDTO/ProtectedResponseDTO.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public class ProtectedResponseDTO {
 
@@ -53,5 +54,29 @@ public class ProtectedResponseDTO {
     public static class protectedPhoneNumber {
         @Schema(description = "전화번호", example = "010-0000-0000")
         private String phoneNumber;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class protectedHealthInfo {
+        @Schema(description = "키", example = "169")
+        private Integer height;
+
+        @Schema(description = "몸무게", example = "60")
+        private Integer weight;
+
+        @Schema(description = "혈액형", example = "RH+A")
+        private String bloodType;
+
+        @Schema(description = "알레르기", example = "[\"집가고싶어 알레르기\", \"페니실린 알레르기\", \"토마토 알러지\"]")
+        private List<String> allergies;
+
+        @Schema(description = "백신", example = "[\"코로나 19\", \"독감 예방주사\", \"백신3\"]")
+        private List<String> vaccines;
+
+        @Schema(description = "수술", example = "[\"다이어트 수술\", \"맹장 수술\", \"수술 3\"]")
+        private List<String> surgeries;
     }
 }

--- a/src/main/java/hansung/ElderCare/Server/repository/Protected_AllergyRepository.java
+++ b/src/main/java/hansung/ElderCare/Server/repository/Protected_AllergyRepository.java
@@ -2,8 +2,17 @@ package hansung.ElderCare.Server.repository;
 
 import hansung.ElderCare.Server.domain.Protected_Allergy;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface Protected_AllergyRepository extends JpaRepository<Protected_Allergy, Long> {
+
+    @Query("select a.allergyName from Protected_Allergy pa JOIN pa.allergy a where pa.Protected.id = :id")
+    List<String> findAllergyNamesByProtectedId(@Param("id") Long protectedId);
+
 }

--- a/src/main/java/hansung/ElderCare/Server/repository/Protected_SurgeryRepository.java
+++ b/src/main/java/hansung/ElderCare/Server/repository/Protected_SurgeryRepository.java
@@ -3,8 +3,15 @@ package hansung.ElderCare.Server.repository;
 import hansung.ElderCare.Server.domain.Protected_Surgery;
 import hansung.ElderCare.Server.domain.Surgery;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface Protected_SurgeryRepository extends JpaRepository<Protected_Surgery, Long> {
+
+    @Query("select s.name from Protected_Surgery ps JOIN ps.surgery s where ps.Protected.id = :id")
+    List<String> findSurgeryNamesByProtectedId(@Param("id") Long protectedId);
 }

--- a/src/main/java/hansung/ElderCare/Server/repository/Protected_VaccineRepository.java
+++ b/src/main/java/hansung/ElderCare/Server/repository/Protected_VaccineRepository.java
@@ -2,8 +2,15 @@ package hansung.ElderCare.Server.repository;
 
 import hansung.ElderCare.Server.domain.Protected_Vaccine;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface Protected_VaccineRepository extends JpaRepository<Protected_Vaccine, Long> {
+
+    @Query("select v.name from Protected_Vaccine pv JOIN pv.vaccine v where pv.Protected.id = :id")
+    List<String> findVaccineNamesByProtectedId(@Param("id") Long protectedId);
 }

--- a/src/main/java/hansung/ElderCare/Server/service/protectedService/ProtectedQueryService.java
+++ b/src/main/java/hansung/ElderCare/Server/service/protectedService/ProtectedQueryService.java
@@ -6,4 +6,6 @@ public interface ProtectedQueryService {
     ProtectedResponseDTO.ProtectedInfo getProtectedInfo(Long userId);
 
     ProtectedResponseDTO.protectedPhoneNumber getPhoneNumber(Long userId);
+
+    ProtectedResponseDTO.protectedHealthInfo getProtectedHealthInfo(Long userId);
 }

--- a/src/main/java/hansung/ElderCare/Server/service/protectedService/ProtectedQueryServiceImpl.java
+++ b/src/main/java/hansung/ElderCare/Server/service/protectedService/ProtectedQueryServiceImpl.java
@@ -4,9 +4,12 @@ import hansung.ElderCare.Server.apiPayload.code.status.ErrorStatus;
 import hansung.ElderCare.Server.apiPayload.exception.ProtectedHandler;
 import hansung.ElderCare.Server.apiPayload.exception.UA_UD_UPHandler;
 import hansung.ElderCare.Server.converter.ProtectedConverter;
-import hansung.ElderCare.Server.domain.Protected;
-import hansung.ElderCare.Server.domain.UA_UD_UP;
+import hansung.ElderCare.Server.domain.*;
+import hansung.ElderCare.Server.domain.enums.BloodType;
 import hansung.ElderCare.Server.dto.ProtectedDTO.ProtectedResponseDTO;
+import hansung.ElderCare.Server.repository.Protected_AllergyRepository;
+import hansung.ElderCare.Server.repository.Protected_SurgeryRepository;
+import hansung.ElderCare.Server.repository.Protected_VaccineRepository;
 import hansung.ElderCare.Server.repository.UA_UD_UPRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,6 +23,10 @@ import java.util.Optional;
 public class ProtectedQueryServiceImpl implements ProtectedQueryService{
 
     private final UA_UD_UPRepository uaUdUpRepository;
+    private final Protected_AllergyRepository protectedAllergyRepository;
+    private final Protected_SurgeryRepository protectedSurgeryRepository;
+    private final Protected_VaccineRepository protectedVaccineRepository;
+
     @Override
     // User의 id를 통해 보호대상자 정보 조회
     // User는 한 명만 있으며 id는 1이라고 가정, 관계테이블에도 해당 유저에 대한 외래키 1을 저장했다고 가정
@@ -66,5 +73,36 @@ public class ProtectedQueryServiceImpl implements ProtectedQueryService{
 
         ProtectedResponseDTO.protectedPhoneNumber protectedPhoneNumber = ProtectedConverter.toProtectedPhoneNumber(aProtected);
         return protectedPhoneNumber;
+    }
+
+    @Override
+    // 보호대상자의 건강정보 get
+    public ProtectedResponseDTO.protectedHealthInfo getProtectedHealthInfo(Long userId) {
+        // 아직 보호대상자 등록되어 있지 않았다면 예외 처리
+        UA_UD_UP uaUdUp = uaUdUpRepository.findByUserIdWithProtected(userId)
+                .orElseThrow(() -> new ProtectedHandler(ErrorStatus.PROTECTED_NULL));
+
+        Long protectedId = uaUdUp.getProtected().getId();
+
+        // 보호대상자의 건강정보 조회
+        Protected aProtected = uaUdUp.getProtected();
+
+        // 건강정보 입력이 필수 입력조건은 아니라 생각해서 예외처리는 하지 않겠으나
+        // 혈액형 enum 클래스를 문자열로 받아오는 경우 건강정보를 입력하지 않아 null일 경우 NullPointerException 발생
+        // 이 부분만 예외처리해서 끊김이 없이 실행되도록 함
+        String bloodType = Optional.ofNullable(aProtected.getBloodType())
+                .map(BloodType::getDisplayName)
+                .orElse(null);
+
+        ProtectedResponseDTO.protectedHealthInfo protectedHealthInfo = ProtectedResponseDTO.protectedHealthInfo.builder()
+                .height(aProtected.getHeight())
+                .weight(aProtected.getWeight())
+                .bloodType(bloodType)
+                .allergies(protectedAllergyRepository.findAllergyNamesByProtectedId(protectedId))
+                .vaccines(protectedVaccineRepository.findVaccineNamesByProtectedId(protectedId))
+                .surgeries(protectedSurgeryRepository.findSurgeryNamesByProtectedId(protectedId))
+                .build();
+
+        return protectedHealthInfo;
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 보호대상자 건강정보 조회
보호대상자 건강정보 입력이 필수사항이 아니라고 생각해 데이터가 없어도 예외가 발생해 실행이 끊기지 않고 클라이언트에게 null 값을
전송하도록 하였음.


## 🔍 테스트 방법
> 1. <테스트 방법을 상세히 적어주세요 (스크린샷 첨부 가능)>
> 건강정보 조회 성공
![image](https://github.com/user-attachments/assets/5d928888-197d-453f-863b-3f3f166b1364)
> 건강정보 null
![image](https://github.com/user-attachments/assets/dcea2802-5664-4268-8613-5528300f2306)
![image](https://github.com/user-attachments/assets/8bb4f8af-8eb0-4320-96d7-7fd82f0c5425)
