### PR TITLE
[#27] Feat: 보호대상자 키, 몸무게 수정

### DIFF
--- a/src/main/java/hansung/ElderCare/Server/controller/ProtectedController.java
+++ b/src/main/java/hansung/ElderCare/Server/controller/ProtectedController.java
@@ -95,4 +95,18 @@ public class ProtectedController implements ProtectedSpecification {
         return ApiResponse.onSuccess(protectedHealthInfo);
     }
 
+    @Override
+    @PutMapping("/update/height-weight")
+    public ApiResponse<?> updateHeightWeight(@RequestBody @Valid ProtectedRequestDTO.HeightWeightDTO request, BindingResult bindingResult) {
+        // 유효성 검사
+        if (bindingResult.hasErrors()) {
+            Map<String, String> validateResult = protectedCommandService.validateHandling(bindingResult);
+
+            return ApiResponse.onFailure(ErrorStatus.PROTECTED_DATA_UNSATISFIED.getCode(),
+                    ErrorStatus.PROTECTED_DATA_UNSATISFIED.getMessage(), validateResult);
+        }
+        ProtectedResponseDTO.protectedHealthInfo response = protectedCommandService.updateHeightWeight(request, 1L);
+        return ApiResponse.onSuccess(response);
+    }
+
 }

--- a/src/main/java/hansung/ElderCare/Server/controller/specification/ProtectedSpecification.java
+++ b/src/main/java/hansung/ElderCare/Server/controller/specification/ProtectedSpecification.java
@@ -15,6 +15,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -43,4 +44,8 @@ public interface ProtectedSpecification {
     @GetMapping
     @Operation(summary = "보호대상자 건강정보 조회", description = "보호대상자 건강정보 조회")
     public ApiResponse<?> getHealthInfo();
+
+    @PutMapping
+    @Operation(summary = "보호대상자 키, 몸무게 수정", description = "보호대상자 키, 몸무게 수정")
+    public ApiResponse<?> updateHeightWeight(ProtectedRequestDTO.HeightWeightDTO request, BindingResult bindingResult);
 }

--- a/src/main/java/hansung/ElderCare/Server/dto/ProtectedDTO/ProtectedRequestDTO.java
+++ b/src/main/java/hansung/ElderCare/Server/dto/ProtectedDTO/ProtectedRequestDTO.java
@@ -111,8 +111,10 @@ public class ProtectedRequestDTO {
     @AllArgsConstructor
     public static class HeightWeightDTO {
         @Schema(description = "키", example = "170")
+        @NotBlank(message = "키는 필수 입력입니다.")
         private Integer height;
 
+        @NotBlank(message = "몸무게는 필수 입력입니다.")
         @Schema(description = "몸무게", example = "70")
         private Integer weight;
     }

--- a/src/main/java/hansung/ElderCare/Server/dto/ProtectedDTO/ProtectedRequestDTO.java
+++ b/src/main/java/hansung/ElderCare/Server/dto/ProtectedDTO/ProtectedRequestDTO.java
@@ -104,4 +104,16 @@ public class ProtectedRequestDTO {
         @ArraySchema(schema = @Schema(description = "수술 목록", example = "[\"다이어트 수술\", \"맹장 수술\"]"))
         private List<String> surgeries;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class HeightWeightDTO {
+        @Schema(description = "키", example = "170")
+        private Integer height;
+
+        @Schema(description = "몸무게", example = "70")
+        private Integer weight;
+    }
 }

--- a/src/main/java/hansung/ElderCare/Server/service/protectedService/ProtectedCommandService.java
+++ b/src/main/java/hansung/ElderCare/Server/service/protectedService/ProtectedCommandService.java
@@ -13,4 +13,6 @@ public interface ProtectedCommandService {
     Map<String, String> validateHandling(BindingResult bindingResult);
 
     Boolean registerHealth(ProtectedRequestDTO.ProtectedHealthInfo request, Long userId);
+
+    ProtectedResponseDTO.protectedHealthInfo updateHeightWeight(ProtectedRequestDTO.HeightWeightDTO request, Long userId);
 }

--- a/src/main/java/hansung/ElderCare/Server/service/protectedService/ProtectedCommandServiceImpl.java
+++ b/src/main/java/hansung/ElderCare/Server/service/protectedService/ProtectedCommandServiceImpl.java
@@ -192,4 +192,28 @@ public class ProtectedCommandServiceImpl implements ProtectedCommandService{
 
         return true;
     }
+
+    @Override
+    // 키 몸무게 수정 후 -> 보호대상자 전체 건강정보 Controller에 반환
+    public ProtectedResponseDTO.protectedHealthInfo updateHeightWeight(ProtectedRequestDTO.HeightWeightDTO request, Long userId) {
+        Protected aProtected = uaUdUpRepository.findByUserIdWithProtected(userId)
+                .orElseThrow(() -> new ProtectedHandler(ErrorStatus.PROTECTED_NULL))
+                .getProtected();
+
+        // 새로운 키, 몸무게 저장
+        aProtected.setHeight(request.getHeight());
+        aProtected.setWeight(request.getWeight());
+        protectedRepository.save(aProtected);
+
+        ProtectedResponseDTO.protectedHealthInfo response = ProtectedResponseDTO.protectedHealthInfo.builder()
+                .height(aProtected.getHeight())
+                .weight(aProtected.getWeight())
+                .bloodType(aProtected.getBloodType().getDisplayName())
+                .allergies(protectedAllergyRepository.findAllergyNamesByProtectedId(aProtected.getId()))
+                .vaccines(protectedVaccineRepository.findVaccineNamesByProtectedId(aProtected.getId()))
+                .surgeries(protectedSurgeryRepository.findSurgeryNamesByProtectedId(aProtected.getId()))
+                .build();
+
+        return response;
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 키, 몸무게 정보를 담은 DTO를 받아서 해당 객체 수정 후 DB update
> 응답으로 보호대상자 건강정보 반환


## 🔍 테스트 방법
> Swagger 테스트
![image](https://github.com/user-attachments/assets/f7c058e2-6951-41a8-9147-0b453b893757)
![image](https://github.com/user-attachments/assets/4973cadb-87e9-487b-ae78-d34144d4b98e)
> 쿼리
![image](https://github.com/user-attachments/assets/3ea4d783-841c-49c7-8051-ee90a743f837)
쿼리 줄일 방법 있으면 말씀좀