### PR TITLE
[#29] Feat: 보호대상자 혈액형 수정

### DIFF
--- a/src/main/java/hansung/ElderCare/Server/controller/ProtectedController.java
+++ b/src/main/java/hansung/ElderCare/Server/controller/ProtectedController.java
@@ -109,4 +109,19 @@ public class ProtectedController implements ProtectedSpecification {
         return ApiResponse.onSuccess(response);
     }
 
+    @Override
+    @PutMapping("/update/bloodtype")
+    public ApiResponse<?> updateBloodType(@RequestBody @Valid ProtectedRequestDTO.BloodTypeDTO request, BindingResult bindingResult) {
+        // 유효성 검사
+        if (bindingResult.hasErrors()) {
+            Map<String, String> validResult = protectedCommandService.validateHandling(bindingResult);
+            return ApiResponse.onFailure(ErrorStatus.PROTECTED_DATA_UNSATISFIED.getCode(),
+                    ErrorStatus.PROTECTED_DATA_UNSATISFIED.getMessage(), validResult);
+        }
+
+        ProtectedResponseDTO.protectedHealthInfo response = protectedCommandService.updateBloodType(request, 1L);
+        return ApiResponse.onSuccess(response);
+    }
+
+
 }

--- a/src/main/java/hansung/ElderCare/Server/controller/specification/ProtectedSpecification.java
+++ b/src/main/java/hansung/ElderCare/Server/controller/specification/ProtectedSpecification.java
@@ -48,4 +48,8 @@ public interface ProtectedSpecification {
     @PutMapping
     @Operation(summary = "보호대상자 키, 몸무게 수정", description = "보호대상자 키, 몸무게 수정")
     public ApiResponse<?> updateHeightWeight(ProtectedRequestDTO.HeightWeightDTO request, BindingResult bindingResult);
+
+    @PutMapping
+    @Operation(summary = "보호대상자 혈액형 수정", description = "보호대상자 혈액형 수정")
+    public ApiResponse<?> updateBloodType(ProtectedRequestDTO.BloodTypeDTO request, BindingResult bindingResult);
 }

--- a/src/main/java/hansung/ElderCare/Server/converter/ProtectedConverter.java
+++ b/src/main/java/hansung/ElderCare/Server/converter/ProtectedConverter.java
@@ -1,11 +1,22 @@
 package hansung.ElderCare.Server.converter;
 
 import hansung.ElderCare.Server.domain.Protected;
+import hansung.ElderCare.Server.domain.enums.BloodType;
 import hansung.ElderCare.Server.dto.ProtectedDTO.ProtectedResponseDTO;
+import hansung.ElderCare.Server.repository.Protected_AllergyRepository;
+import hansung.ElderCare.Server.repository.Protected_SurgeryRepository;
+import hansung.ElderCare.Server.repository.Protected_VaccineRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class ProtectedConverter {
+
+    private final Protected_AllergyRepository protectedAllergyRepository;
+    private final Protected_VaccineRepository protectedVaccineRepository;
+    private final Protected_SurgeryRepository protectedSurgeryRepository;
+
     public static ProtectedResponseDTO.ProtectedInfo toProtectedInfo(Protected aProtected) {
         return ProtectedResponseDTO.ProtectedInfo.builder()
                 .name(aProtected.getName())
@@ -20,6 +31,17 @@ public class ProtectedConverter {
     public static ProtectedResponseDTO.protectedPhoneNumber toProtectedPhoneNumber(Protected aProtected) {
         return ProtectedResponseDTO.protectedPhoneNumber.builder()
                 .phoneNumber(aProtected.getPhoneNumber())
+                .build();
+    }
+
+    public ProtectedResponseDTO.protectedHealthInfo toProtectedHealthInfo(Protected aProtected) {
+        return ProtectedResponseDTO.protectedHealthInfo.builder()
+                .height(aProtected.getHeight())
+                .weight(aProtected.getWeight())
+                .bloodType(aProtected.getBloodType().getDisplayName())
+                .allergies(protectedAllergyRepository.findAllergyNamesByProtectedId(aProtected.getId()))
+                .vaccines(protectedVaccineRepository.findVaccineNamesByProtectedId(aProtected.getId()))
+                .surgeries(protectedSurgeryRepository.findSurgeryNamesByProtectedId(aProtected.getId()))
                 .build();
     }
 }

--- a/src/main/java/hansung/ElderCare/Server/dto/ProtectedDTO/ProtectedRequestDTO.java
+++ b/src/main/java/hansung/ElderCare/Server/dto/ProtectedDTO/ProtectedRequestDTO.java
@@ -118,4 +118,14 @@ public class ProtectedRequestDTO {
         @Schema(description = "몸무게", example = "70")
         private Integer weight;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BloodTypeDTO {
+        @NotBlank(message = "혈액형은 필수 입력입니다.")
+        @Schema(description = "혈액형", example = "RH-A")
+        private String bloodType;
+    }
 }

--- a/src/main/java/hansung/ElderCare/Server/service/protectedService/ProtectedCommandService.java
+++ b/src/main/java/hansung/ElderCare/Server/service/protectedService/ProtectedCommandService.java
@@ -15,4 +15,6 @@ public interface ProtectedCommandService {
     Boolean registerHealth(ProtectedRequestDTO.ProtectedHealthInfo request, Long userId);
 
     ProtectedResponseDTO.protectedHealthInfo updateHeightWeight(ProtectedRequestDTO.HeightWeightDTO request, Long userId);
+
+    ProtectedResponseDTO.protectedHealthInfo updateBloodType(ProtectedRequestDTO.BloodTypeDTO request, Long userId);
 }

--- a/src/main/java/hansung/ElderCare/Server/service/protectedService/ProtectedCommandServiceImpl.java
+++ b/src/main/java/hansung/ElderCare/Server/service/protectedService/ProtectedCommandServiceImpl.java
@@ -13,6 +13,7 @@ import hansung.ElderCare.Server.dto.ProtectedDTO.ProtectedResponseDTO;
 import hansung.ElderCare.Server.repository.*;
 import hansung.ElderCare.Server.service.userService.UserCommandService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.BindingResult;
@@ -27,6 +28,7 @@ import java.util.Optional;
 @Transactional
 @RequiredArgsConstructor
 @Service
+@Slf4j
 public class ProtectedCommandServiceImpl implements ProtectedCommandService{
 
     private final ProtectedRepository protectedRepository;
@@ -203,6 +205,28 @@ public class ProtectedCommandServiceImpl implements ProtectedCommandService{
         // 새로운 키, 몸무게 저장
         aProtected.setHeight(request.getHeight());
         aProtected.setWeight(request.getWeight());
+        protectedRepository.save(aProtected);
+
+        ProtectedResponseDTO.protectedHealthInfo response = ProtectedResponseDTO.protectedHealthInfo.builder()
+                .height(aProtected.getHeight())
+                .weight(aProtected.getWeight())
+                .bloodType(aProtected.getBloodType().getDisplayName())
+                .allergies(protectedAllergyRepository.findAllergyNamesByProtectedId(aProtected.getId()))
+                .vaccines(protectedVaccineRepository.findVaccineNamesByProtectedId(aProtected.getId()))
+                .surgeries(protectedSurgeryRepository.findSurgeryNamesByProtectedId(aProtected.getId()))
+                .build();
+
+        return response;
+    }
+
+    @Override
+    public ProtectedResponseDTO.protectedHealthInfo updateBloodType(ProtectedRequestDTO.BloodTypeDTO request, Long userId) {
+        Protected aProtected = uaUdUpRepository.findByUserIdWithProtected(userId)
+                .orElseThrow(() -> new ProtectedHandler(ErrorStatus.PROTECTED_NULL))
+                .getProtected();
+
+        // 혈액형 저장
+        aProtected.setBloodType(BloodType.fromString(request.getBloodType()));
         protectedRepository.save(aProtected);
 
         ProtectedResponseDTO.protectedHealthInfo response = ProtectedResponseDTO.protectedHealthInfo.builder()

--- a/src/main/java/hansung/ElderCare/Server/service/protectedService/ProtectedCommandServiceImpl.java
+++ b/src/main/java/hansung/ElderCare/Server/service/protectedService/ProtectedCommandServiceImpl.java
@@ -5,6 +5,7 @@ import hansung.ElderCare.Server.apiPayload.exception.ProtectedHandler;
 import hansung.ElderCare.Server.apiPayload.exception.UA_UD_UPHandler;
 import hansung.ElderCare.Server.apiPayload.exception.UserHandler;
 import hansung.ElderCare.Server.converter.AddressConverter;
+import hansung.ElderCare.Server.converter.ProtectedConverter;
 import hansung.ElderCare.Server.domain.*;
 import hansung.ElderCare.Server.domain.enums.BloodType;
 import hansung.ElderCare.Server.domain.enums.Relationship;
@@ -39,6 +40,8 @@ public class ProtectedCommandServiceImpl implements ProtectedCommandService{
     private final Protected_VaccineRepository protectedVaccineRepository;
     private final SurgeryRepository surgeryRepository;
     private final Protected_SurgeryRepository protectedSurgeryRepository;
+
+    private final ProtectedConverter protectedConverter;
 
     @Override
 // 보호대상자 등록
@@ -207,14 +210,7 @@ public class ProtectedCommandServiceImpl implements ProtectedCommandService{
         aProtected.setWeight(request.getWeight());
         protectedRepository.save(aProtected);
 
-        ProtectedResponseDTO.protectedHealthInfo response = ProtectedResponseDTO.protectedHealthInfo.builder()
-                .height(aProtected.getHeight())
-                .weight(aProtected.getWeight())
-                .bloodType(aProtected.getBloodType().getDisplayName())
-                .allergies(protectedAllergyRepository.findAllergyNamesByProtectedId(aProtected.getId()))
-                .vaccines(protectedVaccineRepository.findVaccineNamesByProtectedId(aProtected.getId()))
-                .surgeries(protectedSurgeryRepository.findSurgeryNamesByProtectedId(aProtected.getId()))
-                .build();
+        ProtectedResponseDTO.protectedHealthInfo response = protectedConverter.toProtectedHealthInfo(aProtected);
 
         return response;
     }
@@ -229,14 +225,7 @@ public class ProtectedCommandServiceImpl implements ProtectedCommandService{
         aProtected.setBloodType(BloodType.fromString(request.getBloodType()));
         protectedRepository.save(aProtected);
 
-        ProtectedResponseDTO.protectedHealthInfo response = ProtectedResponseDTO.protectedHealthInfo.builder()
-                .height(aProtected.getHeight())
-                .weight(aProtected.getWeight())
-                .bloodType(aProtected.getBloodType().getDisplayName())
-                .allergies(protectedAllergyRepository.findAllergyNamesByProtectedId(aProtected.getId()))
-                .vaccines(protectedVaccineRepository.findVaccineNamesByProtectedId(aProtected.getId()))
-                .surgeries(protectedSurgeryRepository.findSurgeryNamesByProtectedId(aProtected.getId()))
-                .build();
+        ProtectedResponseDTO.protectedHealthInfo response = protectedConverter.toProtectedHealthInfo(aProtected);
 
         return response;
     }


### PR DESCRIPTION
## 📝 작업 내용
> 보호대상자 혈액형 수정
ProtectedConverter 클래스를 사용해 응답 객체 생성 분리(건강정보 객체 생성은 레포지토리를 사용해야 해서 static이 아닌 일반 클래스 타입)


## 🔍 테스트 방법
> 
![image](https://github.com/user-attachments/assets/9d828349-5ab3-4c45-8da6-69e86fcc2d5e)
![image](https://github.com/user-attachments/assets/d932517b-f584-42c5-836e-a9ce6bb42810)
