### PR TITLE
[#31] Refactor: 보호대상자 건강정보 등록_수정

### DIFF
--- a/src/main/java/hansung/ElderCare/Server/controller/ProtectedController.java
+++ b/src/main/java/hansung/ElderCare/Server/controller/ProtectedController.java
@@ -55,7 +55,7 @@ public class ProtectedController implements ProtectedSpecification {
     }
 
     @Override
-    @GetMapping
+    @GetMapping("/protected")
     public ApiResponse<ProtectedResponseDTO.ProtectedInfo> getProtected() {
         ProtectedResponseDTO.ProtectedInfo protectedInfo = protectedQueryService.getProtectedInfo(1L);
         if (protectedInfo == null) {
@@ -84,8 +84,8 @@ public class ProtectedController implements ProtectedSpecification {
         }
 
         // 전달받은 건강 정보 저장
-        protectedCommandService.registerHealth(request, 1L);
-        return ApiResponse.onSuccess();
+        ProtectedResponseDTO.protectedHealthInfo response = protectedCommandService.registerHealth(request, 3L);
+        return ApiResponse.onSuccess(response);
     }
 
     @Override

--- a/src/main/java/hansung/ElderCare/Server/dto/ProtectedDTO/ProtectedRequestDTO.java
+++ b/src/main/java/hansung/ElderCare/Server/dto/ProtectedDTO/ProtectedRequestDTO.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 public class ProtectedRequestDTO {
@@ -127,5 +128,15 @@ public class ProtectedRequestDTO {
         @NotBlank(message = "혈액형은 필수 입력입니다.")
         @Schema(description = "혈액형", example = "RH-A")
         private String bloodType;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AllergiesDTO {
+        @NotBlank(message = "알레르기는 필수 입력입니다.")
+        @ArraySchema(schema = @Schema(description = "알레르기 목록", example = "[\"집가고싶어알레르기\", \"페니실린 알레르기\"]"))
+        List<String> allergies = new ArrayList<>();
     }
 }

--- a/src/main/java/hansung/ElderCare/Server/repository/Protected_AllergyRepository.java
+++ b/src/main/java/hansung/ElderCare/Server/repository/Protected_AllergyRepository.java
@@ -1,5 +1,6 @@
 package hansung.ElderCare.Server.repository;
 
+import hansung.ElderCare.Server.domain.Allergy;
 import hansung.ElderCare.Server.domain.Protected_Allergy;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/hansung/ElderCare/Server/service/protectedService/ProtectedCommandService.java
+++ b/src/main/java/hansung/ElderCare/Server/service/protectedService/ProtectedCommandService.java
@@ -12,7 +12,7 @@ public interface ProtectedCommandService {
 
     Map<String, String> validateHandling(BindingResult bindingResult);
 
-    Boolean registerHealth(ProtectedRequestDTO.ProtectedHealthInfo request, Long userId);
+    ProtectedResponseDTO.protectedHealthInfo registerHealth(ProtectedRequestDTO.ProtectedHealthInfo request, Long userId);
 
     ProtectedResponseDTO.protectedHealthInfo updateHeightWeight(ProtectedRequestDTO.HeightWeightDTO request, Long userId);
 

--- a/src/main/java/hansung/ElderCare/Server/service/protectedService/ProtectedCommandServiceImpl.java
+++ b/src/main/java/hansung/ElderCare/Server/service/protectedService/ProtectedCommandServiceImpl.java
@@ -21,10 +21,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.validation.Errors;
 import org.springframework.validation.FieldError;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 @Transactional
 @RequiredArgsConstructor
@@ -92,7 +89,7 @@ public class ProtectedCommandServiceImpl implements ProtectedCommandService{
 
     @Override
     // 보호대상자 건강정보 등록
-    public Boolean registerHealth(ProtectedRequestDTO.ProtectedHealthInfo request, Long userId) {
+    public ProtectedResponseDTO.protectedHealthInfo registerHealth(ProtectedRequestDTO.ProtectedHealthInfo request, Long userId) {
 
         // 현재 사용자에 등록되어 있는 보호대상자 있는지 확인
         Optional<UA_UD_UP> uaUdUpOptional = uaUdUpRepository.findByUserIdWithProtected(userId);
@@ -109,93 +106,54 @@ public class ProtectedCommandServiceImpl implements ProtectedCommandService{
 
         protectedRepository.save(aProtected);
 
-        // 요청받은 알레르기 리스트 중 알레르기 테이블에 이미 저장되어 있는 instance가 있는지 확인
+        // 알레르기 리스트 저장
         List<String> allergiesList = request.getAllergies();
-
         for (String allergyName : allergiesList) {
-            Optional<Allergy> allergyOptional = allergyRepository.findByAllergyName(allergyName);
+            Allergy allergy = Allergy.builder()
+                    .allergyName(allergyName)
+                    .build();
 
-            // 이미 저장되어 있는 데이터가 있다면 기존 instance와 관계 테이블 매핑
-            if (allergyOptional.isPresent()) {
-                Protected_Allergy protectedAllergy = Protected_Allergy.builder()
-                        .Protected(aProtected)
-                        .allergy(allergyOptional.get())
-                        .build();
-                protectedAllergyRepository.save(protectedAllergy);
-            }
-            // 그렇지 않고 기존에 저장되어 있는 데이터가 없다면 새로 테이블에 저장 후 관계 테이블 매핑
-            else {
-                Allergy allergy = Allergy.builder()
-                        .allergyName(allergyName)
-                        .build();
-                allergyRepository.save(allergy);
+            allergyRepository.save(allergy);
 
-                Protected_Allergy protectedAllergy = Protected_Allergy.builder()
-                        .allergy(allergy)
-                        .Protected(aProtected)
-                        .build();
-                protectedAllergyRepository.save(protectedAllergy);
-            }
+            Protected_Allergy protectedAllergy = Protected_Allergy.builder()
+                    .Protected(aProtected)
+                    .allergy(allergy)
+                    .build();
+            protectedAllergyRepository.save(protectedAllergy);
         }
 
-        // 요청받은 백신 리스트 중 백신 테이블에 이미 저장되어 있는 instance가 있는지 확인
+        // 백신 리스트 저장
         List<String> vaccinesList = request.getVaccines();
-
         for (String vaccineName : vaccinesList) {
-            Optional<Vaccine> vaccineOptional = vaccineRepository.findByName(vaccineName);
+            Vaccine vaccine = Vaccine.builder()
+                    .name(vaccineName)
+                    .build();
+            vaccineRepository.save(vaccine);
 
-            // 이미 저장되어 있는 백신 데이터가 있다면 기존 인스턴스와 관계 테이블 매핑
-            if (vaccineOptional.isPresent()) {
-                Protected_Vaccine protectedVaccine = Protected_Vaccine.builder()
-                        .Protected(aProtected)
-                        .vaccine(vaccineOptional.get())
-                        .build();
-                protectedVaccineRepository.save(protectedVaccine);
-            }
-            // 해당 백신 이름이 저장되어 있지 않다면 백신 테이블에 백신 데이터 저장 후 기존 인스턴스와 관계 테이블 매핑
-            else {
-                Vaccine vaccine = Vaccine.builder()
-                        .name(vaccineName)
-                        .build();
-                vaccineRepository.save(vaccine);
-
-                Protected_Vaccine protectedVaccine = Protected_Vaccine.builder()
-                        .Protected(aProtected)
-                        .vaccine(vaccine)
-                        .build();
-                protectedVaccineRepository.save(protectedVaccine);
-            }
+            Protected_Vaccine protectedVaccine = Protected_Vaccine.builder()
+                    .Protected(aProtected)
+                    .vaccine(vaccine)
+                    .build();
+            protectedVaccineRepository.save(protectedVaccine);
         }
 
-        // 요청받은 수술 리스트 중 수술 테이블에 이미 저장되어 있는 instance가 있는지 확인
+        // 수술 리스트 저장
         List<String> surgeriesList = request.getSurgeries();
         for (String surgeryName : surgeriesList) {
-            Optional<Surgery> surgeryOptional = surgeryRepository.findByName(surgeryName);
-            // 이미 저장되어 있는 수술 데이터가 있다면 기존 인스턴스와 관계 테이블 매핑
-            if (surgeryOptional.isPresent()) {
-                Protected_Surgery protectedSurgery = Protected_Surgery.builder()
-                        .Protected(aProtected)
-                        .surgery(surgeryOptional.get())
-                        .build();
+            Surgery surgery = Surgery.builder()
+                    .name(surgeryName)
+                    .build();
+            surgeryRepository.save(surgery);
 
-                protectedSurgeryRepository.save(protectedSurgery);
-            }
-            // 해당 수술 이름이 저장되어 있지 않다면 수술 테이블에 수술 데이터 저장 후 기존 인스턴스와 관계 테이블 매핑
-            else {
-                Surgery surgery = Surgery.builder()
-                        .name(surgeryName)
-                        .build();
-                surgeryRepository.save(surgery);
-
-                Protected_Surgery protectedSurgery = Protected_Surgery.builder()
-                        .surgery(surgery)
-                        .Protected(aProtected)
-                        .build();
-                protectedSurgeryRepository.save(protectedSurgery);
-            }
+            Protected_Surgery protectedSurgery = Protected_Surgery.builder()
+                    .Protected(aProtected)
+                    .surgery(surgery)
+                    .build();
+            protectedSurgeryRepository.save(protectedSurgery);
         }
 
-        return true;
+        ProtectedResponseDTO.protectedHealthInfo response = protectedConverter.toProtectedHealthInfo(aProtected);
+        return response;
     }
 
     @Override


### PR DESCRIPTION
## 📝 작업 내용
> 기존에는 알레르기, 백신이력, 수술이력을 등록할 때 해당 테이블이 같은 이름의 데이터가 있다면 기존 레코드와 관계를 맺었으나 요청받을 때마다 DB에 insert하여 새로운 레코드 생성하는 방식으로 수정


## 🔍 테스트 방법
> 1. userId = 2일때
![image](https://github.com/user-attachments/assets/94ad3db1-6b54-45f8-8a8f-049ec177751b)
![image](https://github.com/user-attachments/assets/a0e51eae-8fba-4cf8-aa42-64c09523fd73)
> 2. userId = 3일때
![image](https://github.com/user-attachments/assets/0f62c71d-7de7-4ef4-9258-964fbc4a52c2)
![image](https://github.com/user-attachments/assets/eeab3736-24fc-4bda-a2ad-5a4d176abcae)
