### PR TITLE
feat/#41 보호대상자 정보 수정

### DIFF
--- a/src/main/java/hansung/ElderCare/Server/controller/ProtectedController.java
+++ b/src/main/java/hansung/ElderCare/Server/controller/ProtectedController.java
@@ -55,7 +55,12 @@ public class ProtectedController implements ProtectedSpecification {
     }
 
     @Override
-    public ApiResponse<?> updateProtected(ProtectedRequestDTO.RegistrationDTO request, MultipartFile image) {
+    public ApiResponse<?> updateProtected(ProtectedRequestDTO.RegistrationDTO request, MultipartFile image, BindingResult bindingResult) {
+
+        if (bindingResult.hasErrors()) {
+            return ApiResponse.onFailure(ErrorStatus.PROTECTED_DATA_UNSATISFIED.getCode(), ErrorStatus.PROTECTED_DATA_UNSATISFIED.getMessage(),
+                    protectedCommandService.validateHandling(bindingResult));
+        }
         // 보호대상자 정보 수정 후 보호대상자 정보 return
         return ApiResponse.onSuccess(protectedCommandService.updateProtected(request, 1L));
     }

--- a/src/main/java/hansung/ElderCare/Server/controller/ProtectedController.java
+++ b/src/main/java/hansung/ElderCare/Server/controller/ProtectedController.java
@@ -55,6 +55,12 @@ public class ProtectedController implements ProtectedSpecification {
     }
 
     @Override
+    public ApiResponse<?> updateProtected(ProtectedRequestDTO.RegistrationDTO request, MultipartFile image) {
+        // 보호대상자 정보 수정 후 보호대상자 정보 return
+        return ApiResponse.onSuccess(protectedCommandService.updateProtected(request, 1L));
+    }
+
+    @Override
     @GetMapping("/protected")
     public ApiResponse<ProtectedResponseDTO.ProtectedInfo> getProtected() {
         ProtectedResponseDTO.ProtectedInfo protectedInfo = protectedQueryService.getProtectedInfo(1L);

--- a/src/main/java/hansung/ElderCare/Server/controller/specification/ProtectedSpecification.java
+++ b/src/main/java/hansung/ElderCare/Server/controller/specification/ProtectedSpecification.java
@@ -30,10 +30,10 @@ public interface ProtectedSpecification {
 
     @Operation(summary = "보호대상자 정보 수정", description = "보호대상자의 데이터를 받아 수정합니다.")
     @PatchMapping(value = "/update", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    // 수정 데이터는 유효성 검사 X
     public ApiResponse<?> updateProtected(
-            @RequestPart(value = "request") @Parameter(description = "보호대상자 정보(JSON)") ProtectedRequestDTO.RegistrationDTO request,
-            @RequestPart(value = "image", required = false) @Parameter(description = "보호대상자 프로필 이미지") MultipartFile image
+            @RequestPart(value = "request") @Valid @Parameter(description = "보호대상자 정보(JSON)") ProtectedRequestDTO.RegistrationDTO request,
+            @RequestPart(value = "image", required = false) @Parameter(description = "보호대상자 프로필 이미지") MultipartFile image,
+            BindingResult bindingResult
     );
 
     @GetMapping

--- a/src/main/java/hansung/ElderCare/Server/controller/specification/ProtectedSpecification.java
+++ b/src/main/java/hansung/ElderCare/Server/controller/specification/ProtectedSpecification.java
@@ -13,11 +13,10 @@ import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.Errors;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import javax.print.attribute.standard.Media;
 
 public interface ProtectedSpecification {
 
@@ -27,6 +26,14 @@ public interface ProtectedSpecification {
             @RequestPart(value = "request") @Valid @Parameter(description = "보호대상자 정보(JSON)") ProtectedRequestDTO.RegistrationDTO request,
             @RequestPart(value = "image", required = false) @Parameter(description = "보호대상자 프로필 이미지") MultipartFile image,
             BindingResult bindingResult
+    );
+
+    @Operation(summary = "보호대상자 정보 수정", description = "보호대상자의 데이터를 받아 수정합니다.")
+    @PatchMapping(value = "/update", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    // 수정 데이터는 유효성 검사 X
+    public ApiResponse<?> updateProtected(
+            @RequestPart(value = "request") @Parameter(description = "보호대상자 정보(JSON)") ProtectedRequestDTO.RegistrationDTO request,
+            @RequestPart(value = "image", required = false) @Parameter(description = "보호대상자 프로필 이미지") MultipartFile image
     );
 
     @GetMapping

--- a/src/main/java/hansung/ElderCare/Server/domain/Address.java
+++ b/src/main/java/hansung/ElderCare/Server/domain/Address.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Embeddable
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 public class Address {

--- a/src/main/java/hansung/ElderCare/Server/domain/Protected.java
+++ b/src/main/java/hansung/ElderCare/Server/domain/Protected.java
@@ -10,7 +10,7 @@ import java.time.LocalDate;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@Builder(toBuilder = true)
 public class Protected {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/hansung/ElderCare/Server/domain/UA_UD_UP.java
+++ b/src/main/java/hansung/ElderCare/Server/domain/UA_UD_UP.java
@@ -7,7 +7,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-@Builder
+@Builder(toBuilder = true)
 @Setter
 public class UA_UD_UP {
     @Id

--- a/src/main/java/hansung/ElderCare/Server/service/protectedService/ProtectedCommandService.java
+++ b/src/main/java/hansung/ElderCare/Server/service/protectedService/ProtectedCommandService.java
@@ -23,4 +23,6 @@ public interface ProtectedCommandService {
     ProtectedResponseDTO.protectedHealthInfo updateVaccine(ProtectedRequestDTO.VaccinesDTO request, Long userId);
 
     ProtectedResponseDTO.protectedHealthInfo updateSurgery(ProtectedRequestDTO.SurgeriesDTO request, Long userId);
+
+    ProtectedResponseDTO.ProtectedInfo updateProtected(ProtectedRequestDTO.RegistrationDTO request, Long userId);
 }

--- a/src/main/java/hansung/ElderCare/Server/service/protectedService/ProtectedCommandServiceImpl.java
+++ b/src/main/java/hansung/ElderCare/Server/service/protectedService/ProtectedCommandServiceImpl.java
@@ -270,4 +270,43 @@ public class ProtectedCommandServiceImpl implements ProtectedCommandService{
         }
         return protectedConverter.toProtectedHealthInfo(aProtected);
     }
+
+    @Override
+    public ProtectedResponseDTO.ProtectedInfo updateProtected(ProtectedRequestDTO.RegistrationDTO request, Long userId) {
+
+        UA_UD_UP uaUdUp = uaUdUpRepository.findByUserIdWithProtected(userId)
+                .orElseThrow(() -> new UA_UD_UPHandler(ErrorStatus.PROTECTED_NULL));
+
+        Protected aProtected = uaUdUp.getProtected();
+
+        // request 값과 다르면 update 그렇지 않으면 기존 객체 내용을 따르는 toBuilder() 메소드
+        Protected updatedProtected = aProtected.toBuilder()
+                .name(request.getName())
+                .birthDate(request.getBirthDate())
+                .nickname(request.getNickname())
+                .phoneNumber(request.getPhoneNumber())
+                .address(request.getAddress() != null ?
+                        Address.builder()
+                                .zipCode(request.getAddress().getZipcode())
+                                .building(request.getAddress().getBuilding())
+                                .detailedAddress(request.getAddress().getDetailedAddress())
+                                .build():
+                        aProtected.getAddress()
+                ).build();
+
+        protectedRepository.save(updatedProtected);
+
+        uaUdUp = uaUdUp.toBuilder()
+                .Protected(updatedProtected)
+                .build();
+        uaUdUpRepository.save(uaUdUp);
+
+        return ProtectedResponseDTO.ProtectedInfo.builder()
+                .name(updatedProtected.getName())
+                .birthDate(updatedProtected.getBirthDate())
+                .nickname(updatedProtected.getNickname())
+                .phoneNumber(updatedProtected.getPhoneNumber())
+                .address(AddressConverter.toResponseAddressDTO(updatedProtected.getAddress()))
+                .build();
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 보호대상자 정보를 받아올 때 DTO는 보호대상자 정보 등록할 때 DTO랑 데이터가 똑같아서 RegistrationDTO로 했음.
> Setter 안 쓰고 toBuilder 메소드로 Builder 패턴 사용하면서 데이터 수정
> 데이터 수정 후 Protected 테이블과 UA_UD_UP 테이블 동시 반영


## 🔍 테스트 방법
> 1. <테스트 방법을 상세히 적어주세요 (스크린샷 첨부 가능)>
![image](https://github.com/user-attachments/assets/88874f6f-18fa-4b36-a585-ed97c1101539)
![image](https://github.com/user-attachments/assets/b4f403b3-0473-4240-8433-70a753393721)
